### PR TITLE
迁移到 weblate

### DIFF
--- a/assets/strings/en.ini
+++ b/assets/strings/en.ini
@@ -1,6 +1,14 @@
 # Aseprite
 # Copyright (C) 2018-2023  Igara Studio S.A.
 # Copyright (C) 2016-2018  David Capello
+# 
+# This work is licensed under the Creative Commons Attribution 4.0
+# International License. To view a copy of this license, visit
+# http://creativecommons.org/licenses/by/4.0/ or send a letter to
+# Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+[_]
+display_name = English
 
 [advanced_mode]
 title = Warning - Important
@@ -41,89 +49,29 @@ non_transformable_reference_layer = Layer '{}' is reference, cannot be transform
 sprite_locked_somewhere = The sprite is locked in other editor
 not_enough_transform_memory = Not enough memory to transform the selection
 not_enough_rotsprite_memory = Not enough memory for RotSprite
-cannot_modify_readonly_sprite = <<<END
-Cannot modify a read-only sprite.
-Use File > Save menu for more information.
-END
+cannot_modify_readonly_sprite = Cannot modify a read-only sprite.\nUse "File > Save" menu for more information.
 
 [alerts]
 applying_filter = FX<<Applying effect...||&Cancel
-auto_remap = <<<END
-Automatic Remap
-<<The remap operation cannot be perfectly done for more than 256 colors.
-<<Do you want to continue anyway?
-||&OK||&Cancel"
-END
+auto_remap = Automatic Remap\n<<The remap operation cannot be perfectly done for more than 256 colors.\n<<Do you want to continue anyway?\n||&OK||&Cancel
 cannot_delete_all_layers = Error<<You cannot delete all layers.||&OK
-cannot_delete_used_tileset = <<<END
-Error
-<<Cannot delete tileset used by the following tilemaps:
-<<'{0}'
-||&OK
-END
-deleting_tilemaps_will_delete_tilesets = <<<END
-Warning
-<<Deleting the following layers will delete their tilesets:
-<<'{0}'
-<<Do you want to continue anyway?
-||&OK||&Cancel
-END
-cannot_file_overwrite_on_export = <<<END
-Overwrite Warning
-<<You cannot Export with the same name (overwrite the original file).
-<<Use File > Save As menu option in that case.
-||&OK
-END
+cannot_delete_used_tileset = Error\n<<Cannot delete tileset used by the following tilemaps:\n<<'{0}'\n||&OK
+deleting_tilemaps_will_delete_tilesets = Warning\n<<Deleting the following tilemaps will delete their tilesets:\n<<'{0}'\n<<Do you want to continue anyway?\n||&OK||&Cancel
+cannot_file_overwrite_on_export = Overwrite Warning\n<<You cannot Export with the same name (overwrite the original file).\n<<Use "File > Save As" menu option in that case.\n||&OK
 cannot_open_file = Problem<<Cannot open file:<<{0}||&OK
 cannot_open_folder = Problem<<Cannot open folder:<<{0}||&OK
 cannot_save_in_read_only_file = Problem<<The selected file is read-only. Try with other file.||&Go back
 clipboard_access_locked = Error<<Cannot access to the clipboard.<<Maybe other application is using it.||&OK
 clipboard_image_format_not_supported = Error<<The current clipboard image format is not supported.||&OK
-delete_selected_backups = <<<END
-Warning
-<<Do you really want to delete the selected {0} backup(s)?
-||&Yes||&No
-END
-delete_shortcut = <<<END
-Warning
-<<Do you really want to delete '{0}' keyboard shortcut?
-||&Yes||&No
-END
-empty_rect_importing_sprite_sheet = <<<END
-Import Sprite Sheet
-<<The specified rectangle does not create any tile.
-<<Select a rectangle inside the sprite region.
-||&OK
-END
+delete_selected_backups = Warning\n<<Do you really want to delete the selected {0} backup(s)?\n||&Yes||&No
+delete_shortcut = Warning\n<<Do you really want to delete '{0}' keyboard shortcut?\n||&Yes||&No
+empty_rect_importing_sprite_sheet = Import Sprite Sheet\n<<The specified rectangle does not create any tile.\n<<Select a rectangle inside the sprite region.\n||&OK
 error_loading_file = Error<<Error loading file: {0}||&OK
 error_saving_file = Error<<Error saving file: {0}||&OK
 file_format_doesnt_support_palette = Error<<Cannot save a color palette in {0} format||&OK
-export_animation_in_sequence = <<<END
-Notice
-<<Do you want to export the animation in {0} files?
-<<{1}, {2}...
-||&Agree||&Cancel
-END
-file_format_doesnt_support_error = <<<END
-Error
-<<File format ".{0}" doesn't support:
-<<
-{1}
-<<
-<<You must select other format.
-<<Use ".aseprite" to keep all the sprite information.
-||&OK
-END
-file_format_doesnt_support_warning = <<<END
-Warning
-<<File format ".{0}" doesn't support:
-<<
-{1}
-<<
-<<You can use ".aseprite" format to keep all this information.
-<<Do you want continue with ".{0}" anyway?
-||&Yes||&No
-END
+export_animation_in_sequence = Notice\n<<Do you want to export the animation in {0} files?\n<<{1}, {2}...\n||&Agree||&Cancel
+file_format_doesnt_support_error = Error\n<<File format ".{0}" doesn't support:\n<<\n{1}\n<<\n<<You must select other format.\n<<Use ".aseprite" to keep all the sprite information.\n||&OK
+file_format_doesnt_support_warning = Warning\n<<File format ".{0}" doesn't support:\n<<\n{1}\n<<\n<<You can use ".aseprite" format to keep all this information.\n<<Do you want continue with ".{0}" anyway?\n||&Yes||&No
 file_format_alpha_channel = Alpha channel
 file_format_tags = Tags
 file_format_frames = Frames
@@ -134,106 +82,32 @@ file_format_palette_changes = Palette changes between frames
 file_format_rgb_mode = RGB mode
 file_format_20ms_min_duration = Frame duration less than 20ms
 file_format_10ms_duration_precision = Frame duration other than a multiple of 10ms
-invalid_chars_in_filename = <<<END
-Error
-<<The file name cannot contain the following character(s):
-<< {0}
-||&OK
-END
-invalid_fg_or_bg_colors = <<<END
-Aseprite
-<<The current selected foreground and/or background color
-<<is out of range. Select a valid color in the palette.
-||&OK
-END
+invalid_chars_in_filename = Error\n<<The file name cannot contain the following character(s):\n<< {0}\n||&OK
+invalid_fg_or_bg_colors = Aseprite\n<<The current selected foreground and/or background color\n<<is out of range. Select a valid color in the palette.\n||&OK
 job_working = {0}<<Working...||&Cancel
 nothing_to_report = Crash Report<<Nothing to report||&OK
-install_extension = <<<END
-Warning
-<<Do you really want to install the given extension?
-<<'{0}'
-||&Install||&Cancel
-END
-uninstall_extension_warning = <<<END
-Warning
-<<Do you really want to uninstall '{0}' extension?
-||&Yes||&No
-END
-unknown_output_file_format_error = <<<END
-Aseprite
-<<Unknown file format '{0}' in output filename
-||&OK
-END
-update_screen_ui_scaling_with_theme_values = <<<END
-Update Screen/UI Scaling
-<<The new theme '{0}' wants to adjust some values for you:
-<<  Screen Scaling: {1}% -> {2}%
-<<  UI Scaling: {3}% -> {4}%
-<<Allow these changes?
-||&Adjust Scaling||&Don't Adjust Scaling
-END
-update_extension = <<<END
-Update Extension
-<<The extension '{0}' already exists.
-<<Do you want to {1} from v{2} to v{3}?
-||&Yes||&No
-END
+install_extension = Warning\n<<Do you really want to install the given extension?\n<<'{0}'\n||&Install||&Cancel
+uninstall_extension_warning = Warning\n<<Do you really want to uninstall '{0}' extension?\n||&Yes||&No
+unknown_output_file_format_error = Aseprite\n<<Unknown file format '{0}' in output filename\n||&OK
+update_screen_ui_scaling_with_theme_values = Update Screen/UI Scaling\n<<The new theme '{0}' wants to adjust some values for you:\n<<  Screen Scaling: {1}% -> {2}%\n<<  UI Scaling: {3}% -> {4}%\n<<Allow these changes?\n||&Adjust Scaling||&Don't Adjust Scaling
+update_extension = Update Extension\n<<The extension '{0}' already exists.\n<<Do you want to {1} from v{2} to v{3}?\n||&Yes||&No
 update_extension_downgrade = downgrade
 update_extension_upgrade = upgrade
 recent_file_doesnt_exist = Aseprite<<The selected file doesn't exist||&OK
 recent_folder_doesnt_exist = Aseprite<<The selected folder doesn't exist||&OK
-restart_by_preferences = <<<END
-Aseprite
-<<You must restart the program to see your changes to:{0}
-||&OK
-END
+restart_by_preferences = Aseprite\n<<You must restart the program to see your changes to:{0}\n||&OK
 restart_by_preferences_save_recovery_data_period = Automatically save recovery data every X minutes
 restart_by_preferences_keep_edited_sprite_data_lifespan = Keep edited sprite data for X days
 restart_by_preferences_keep_closed_sprite_on_memory_for = Keep closed sprite on memory for X minutes
-restore_all_shortcuts = <<<END
-Warning
-<<Do you want to restore all keyboard shortcuts
-<<to their original default settings?
-||&Yes||&No
-END
-run_script = <<<END
-Run Script
-<<Do you want to run the following script?
-<<
-<<  {0}
-<<
-<<WARNING: Scripts can crash Aseprite, please save your work
-<<before running a script.
-||&Run||&Cancel
-END
-save_sprite_changes = <<<END
-Warning
-<<Saving changes to the sprite
-<<"{0}" before {1}?
-||&Save||Do&n't Save||&Cancel
-END
+restore_all_shortcuts = Warning\n<<Do you want to restore all keyboard shortcuts\n<<to their original default settings?\n||&Yes||&No
+run_script = Run Script\n<<Do you want to run the following script?\n<<\n<<  {0}\n<<\n<<WARNING: Scripts can crash Aseprite, please save your work\n<<before running a script.\n||&Run||&Cancel
+save_sprite_changes = Warning\n<<Saving changes to the sprite\n<<"{0}" before {1}?\n||&Save||Do&n't Save||&Cancel
 save_sprite_changes_quitting = quitting
 save_sprite_changes_closing = closing
 overwrite_existent_file = Warning<<File exists, overwrite it?<<{0}||&Yes||&No||&Cancel
-overwrite_files_on_export_sprite_sheet = <<<END
-Export Sprite Sheet Warning
-<<Do you want to overwrite the following file(s)?
-{0}
-||&Yes||&No
-END
-overwrite_files_on_export = <<<END
-Export Warning
-<<Do you want to overwrite the following file?
-<<{0}
-||&Yes||&No
-END
-enter_license_disabled = <<<END
-Information
-<<This copy of Aseprite does not support entering a license key.
-<<Consider getting one from https://aseprite.org/download.
-<<Activating Aseprite will give you access to automatic updates.
-||&OK
-END
+overwrite_files_on_export_sprite_sheet = Export Sprite Sheet Warning\n<<Do you want to overwrite the following file(s)?\n{0}\n||&Yes||&No
+overwrite_files_on_export = Export Warning\n<<Do you want to overwrite the following file?\n<<{0}\n||&Yes||&No
+enter_license_disabled = Information\n<<This copy of Aseprite does not support entering a license key.\n<<Consider getting one from https://aseprite.org/download.\n<<Activating Aseprite will give you access to automatic updates.\n||&OK
 
 [brightness_contrast]
 title = Brightness/Contrast
@@ -281,18 +155,9 @@ sort_and_gradients = Sort & Gradients
 presets = Presets
 options = Options
 switch_tileset = Show Tileset / Right-click to Show Only the Tileset
-tileset_mode_manual = <<<END
-Manual: Modify existent tiles,
-don't create new tiles automatically
-END
-tileset_mode_auto = <<<END
-Auto: Modify and reuse existent tiles,
-create/delete tiles if needed/possible
-END
-tileset_mode_stack = <<<END
-Stack: Don't modify existent tiles,
-generate and stack new tiles automatically
-END
+tileset_mode_manual = Manual: Modify existent tiles,\ndon't create new tiles automatically
+tileset_mode_auto = Auto: Modify and reuse existent tiles,\ncreate/delete tiles if needed/possible
+tileset_mode_stack = Stack: Don't modify existent tiles,\ngenerate and stack new tiles automatically
 set_as_default = Set As Default
 remap_palette = Remap Palette
 remap_palette_tooltip = Matches old indexes with new indexes
@@ -367,7 +232,7 @@ ChangePixelFormat_Grayscale = Grayscale
 ChangePixelFormat_Indexed = Indexed
 ChangePixelFormat_Indexed_OrderedDithering = Indexed with Ordered Dithering
 ChangePixelFormat_Indexed_OldDithering = Indexed with Old Dithering
-ChangePixelFormat_Indexed_ErrorDifussion = Indexed with Floyd-Steinberg Error Diffusion Dithering
+ChangePixelFormat_Indexed_ErrorDiffusion = Indexed with Floyd-Steinberg Error Diffusion Dithering
 ChangePixelFormat_MoreOptions = More Options
 Clear = Clear
 ClearCel = Clear Cel
@@ -503,19 +368,11 @@ OpenInFolder = Open In Folder
 OpenScriptFolder = Open Script Folder
 OpenWithApp = Open With Associated Application
 Options = Preferences
-PaletteEditor = Switch{0}{1}{2}
-PaletteEditor_Edit = <<<END
- Edit Palette Mode
-END
-PaletteEditor_And = <<<END
- and
-END
-PaletteEditor_FgPopup = <<<END
- Foreground Color Popup
-END
-PaletteEditor_BgPopup = <<<END
- Background Color Popup
-END
+PaletteEditor = Switch {0} {1} {2}
+PaletteEditor_Edit = Edit Palette Mode
+PaletteEditor_And = and
+PaletteEditor_FgPopup = Foreground Color Popup
+PaletteEditor_BgPopup = Background Color Popup
 PaletteSize = Palette Size
 Paste = Paste
 PasteText = Insert Text
@@ -653,30 +510,15 @@ width = Width:
 height = Height:
 borders = Borders:
 left = Left:
-left_tooltip = <<<END
-Columns to be added/removed in the left side.
-Use a negative number to remove columns.
-END
+left_tooltip = Columns to be added/removed in the left side.\nUse a negative number to remove columns.
 top = Top:
-top_tooltip = <<<END
-Rows to be added/removed in the top side.
-Use a negative number to remove rows
-END
+top_tooltip = Rows to be added/removed in the top side.\nUse a negative number to remove rows
 right = Right:
-right_tooltip = <<<END
-Columns to be added/removed in the right side.
-Use a negative number to remove columns.
-END
+right_tooltip = Columns to be added/removed in the right side.\nUse a negative number to remove columns.
 bottom = Bottom:
-bottom_tooltip = <<<END
-Rows to be added/removed in the bottom side.
-Use a negative number to remove rows.
-END
+bottom_tooltip = Rows to be added/removed in the bottom side.\nUse a negative number to remove rows.
 trim = &Trim content outside the canvas
-trim_tooltip = <<<END
-Remove pixels from image cels that will
-be left outside the new canvas size.
-END
+trim_tooltip = Remove pixels from image cels that will\nbe left outside the new canvas size.
 
 [cel_properties]
 title = Cel Properties
@@ -775,24 +617,15 @@ pressure_tooltip = Control parameters through the pen pressure sensor
 velocity = Velocity
 velocity_tooltip = Control parameters through the mouse velocity
 size = Size
-size_tooltip = <<<END
-Change the brush size
-depending on the sensor value
-END
+size_tooltip = Change the brush size\ndepending on the sensor value
 angle = Angle
-angle_tooltip = <<<END
-Change the brush angle
-depending on the sensor value
-END
+angle_tooltip = Change the brush angle\ndepending on the sensor value
 min_size_tooltip = Brush size when the sensor has its minimum value
 max_size_tooltip = Brush size when the sensor has its maximum value
 min_angle_tooltip = Brush angle when the sensor has its minimum value
 max_angle_tooltip = Brush angle when the sensor has its maximum value
 gradient = Gradient
-gradient_tooltip = <<<END
-Gradient between foreground
-and background colors
-END
+gradient_tooltip = Gradient between foreground\nand background colors
 max_point_value = Min/Max Values
 sensors_tweaks = Sensor Threshold
 
@@ -806,10 +639,7 @@ frames = Frames:
 anidir = Animation Direction:
 pixel_ratio = Apply pixel ratio
 for_twitter = Export for Twitter
-for_twitter_tooltip = <<<END
-Adjust the duration of the last frame to 1/4 so
-Twitter reproduces the animation correctly.
-END
+for_twitter_tooltip = Adjust the duration of the last frame to 1/4 so\nTwitter reproduces the animation correctly.
 adjust_resize = Adjust resize to {0}%
 export = &Export
 cancel = &Cancel
@@ -822,35 +652,20 @@ sprite = Sprite
 sprite_tooltip = Source of sprite samples to export in the sprite sheet
 borders = Borders
 borders_tooltip = Add or trim borders from each sprite in the sprite sheet
-expand_all_sections_tooltip = <<<END
-Show all sections
-
-Use Ctrl+click to display multiple sections at the same time
-END
+expand_all_sections_tooltip = Show all sections\n\nUse Ctrl + Click to display multiple sections at the same time
 layout = Layout
 layout_tooltip = Arrangement of sprites in the final result
 output = Output
 output_tooltip = Where to store the sprite sheet
 sheet_type = Sheet Type:
-sheet_type_tooltip = <<<END
-Indicates a specific way to layout sprites in the sprite sheet:
-* Horizontal: Each frame side by side.
-* Vertical: Each frame one below the other.
-* By Rows: Create one row for each layer or tag.
-* By Columns: Create one column for each layer or tag.
-* Packed: Try to fit all frames in the best possible way.
-END
+sheet_type_tooltip = Indicates a specific way to layout sprites in the sprite sheet:\n* Horizontal: Each frame side by side.\n* Vertical: Each frame one below the other.\n* By Rows: Create one row for each layer or tag.\n* By Columns: Create one column for each layer or tag.\n* Packed: Try to fit all frames in the best possible way.
 type_horz = Horizontal Strip
 type_vert = Vertical Strip
 type_rows = By Rows
 type_cols = By Columns
 type_pack = Packed
 constraints = Constraints:
-constraints_tooltip = <<<END
-Special constraints for the sprite sheet.
-E.g. Fixed number of rows/columns or fixed
-number of pixels (width/height).
-END
+constraints_tooltip = Special constraints for the sprite sheet.\nE.g. Fixed number of rows/columns or fixed\nnumber of pixels (width/height).
 constraint_fixed_none = None
 constraint_fixed_cols = Fixed # of Columns
 constraint_fixed_rows = Fixed # of Rows
@@ -860,10 +675,7 @@ constraint_fixed_size = Fixed Size
 border = Border Padding:
 border_tooltip = Space between each frame and the edge of the sprite sheet
 shape = Spacing:
-shape_tooltip = <<<END
-Space between each frame in the sprite sheet
-(a.k.a "Shape Padding")
-END
+shape_tooltip = Space between each frame in the sprite sheet\n(a.k.a "Shape Padding")
 inner = Inner Padding:
 inner_tooltip = Extra space inside frame edges
 trim_sprite = Trim Sprite
@@ -894,18 +706,9 @@ meta_layers = Layers
 meta_tags = Tags
 meta_slices = Slices
 data_filename_format = Item Filename:
-data_filename_format_tooltip = <<<END
-Each frame in the JSON data will contain a filename
-(string that identifies them), this field describes
-how to build each frame. You can use special marks
-like {layer}, {frame}, {tag}, {tagframe}, etc.
-END
+data_filename_format_tooltip = Each frame in the JSON data will contain a filename\n(string that identifies them), this field describes\nhow to build each frame. You can use special marks\nlike {layer}, {frame}, {tag}, {tagframe}, etc.
 data_tagname_format = Item Tagname:
-data_tagname_format_tooltip = <<<END
-Each tag in the JSON data will have a name
-field, you can customize this name using fields
-like {filename}, {title}, {path}, {tag}, etc.
-END
+data_tagname_format_tooltip = Each tag in the JSON data will have a name\nfield, you can customize this name using fields\nlike {filename}, {title}, {path}, {tag}, etc.
 preview = Preview
 open_sprite_sheet = Open Sprite Sheet
 export = &Export
@@ -962,10 +765,7 @@ no = &No
 cancel = &Cancel
 user_data = User Data
 dont_show = Don't show this alert again
-dont_show_tooltip = <<<END
-Check in case that you want to establish
-the given option as the default option.
-END
+dont_show_tooltip = Check in case that you want to establish\nthe given option as the default option.
 reset = Reset
 advanced_options = Advanced Options
 unknown = Unknown
@@ -996,17 +796,9 @@ title = Home
 new_file = New File...
 open_file = Open File...
 recover_files = Recover Files...
-recover_files_tooltip = <<<END
-Recover files from crashed sessions or
-closed sprite that were not saved in
-previous sessions.
-END
+recover_files_tooltip = Recover files from crashed sessions or\nclosed sprite that were not saved in\nprevious sessions.
 share_crashdb = Share crash data with Aseprite developers
-share_crashdb_tooltip = <<<END
-Check to share crash data with Aseprite developers automatically.
-This will help to find new bugs and improve the general stability
-of Aseprite for all users.
-END
+share_crashdb_tooltip = Check to share crash data with Aseprite developers automatically.\nThis will help to find new bugs and improve the general stability\nof Aseprite for all users.
 recent_files = Recent files:
 recent_folders = Recent folders:
 news = News:
@@ -1036,22 +828,14 @@ cancel = &Cancel
 
 [incompat_file]
 title = Incompatible File
-message = <<<END
-This file was originally created with a newer version of Aseprite which contains information we cannot fully read.
-
-It's marked as read-only to avoid losing that information when you try to save/overwrite it.
-
-To solve this situation you can:
-- Update Aseprite to the latest version and try to load the file again (recommended), or
-- Use the "File > Save As" option to save the file with other name (you will lose information stored in the original file anyway)
-END
+message = This file was originally created with a newer version of Aseprite which contains information we cannot fully read.\n\nIt's marked as read-only to avoid losing that information when you try to save/overwrite it.\n\nTo solve this situation you can:\n- Update Aseprite to the latest version and try to load the file again (recommended), or\n- Use the "File > Save As" option to save the file with other name (you will lose information stored in the original file anyway)
 incompatibilities = Incompatibilities:
 update_link = Update Aseprite
 
 [inks]
 simple_ink = Simple Ink
 alpha_compositing = Alpha Compositing
-copy_color = Copy Alpha+Color
+copy_color = Copy Alpha + Color
 lock_alpha = Lock Alpha
 shading = Shading
 
@@ -1413,16 +1197,9 @@ grid_height = Grid Height:
 name = Name:
 default_name = Tileset
 base_index = Base Index:
-base_tooltip = <<<END
-Visible aid to see the first tile with content from the tileset
-as index 1 (by default, one-based index) or other value.
-E.g. you can use 0 here for zero-based indexing.
-END
+base_tooltip = Visible aid to see the first tile with content from the tileset\nas index 1 (by default, one-based index) or other value.\nE.g. you can use 0 here for zero-based indexing.
 allowed_flips = Allowed Flips:
-allowed_flips_tooltip = <<<END
-Aseprite can reuse tiles matching automatically with their flipped
-versions (in X, Y, or Diagonal axes) in Auto/Stack modes.
-END
+allowed_flips_tooltip = Aseprite can reuse tiles matching automatically with their flipped\nversions (in X, Y, or Diagonal axes) in Auto/Stack modes.
 
 [tileset_selector_window]
 title = Tileset
@@ -1436,18 +1213,9 @@ color_mode = Color Mode:
 rgba = &RGBA
 grayscale = &Grayscale
 indexed = &Indexed
-rgba_tooltip = <<<END
-Each pixel has Red, Green, Blue, and Alpha components
-(32 bits per pixel)
-END
-grayscale_tooltip = <<<END
-Each pixel has a Gray value and Alpha
-(16 bits per pixel)
-END
-indexed_tooltip = <<<END
-Each pixel is a reference to the palette
-(8 bits per pixel)
-END
+rgba_tooltip = Each pixel has Red, Green, Blue, and Alpha components\n(32 bits per pixel)
+grayscale_tooltip = Each pixel has a Gray value and Alpha\n(16 bits per pixel)
+indexed_tooltip = Each pixel is a reference to the palette\n(8 bits per pixel)
 background = Background:
 transparent = &Transparent
 white = &White
@@ -1495,14 +1263,8 @@ section_extensions = Extensions
 section_experimental = Experimental
 general = General
 ui_windows = User Interface:
-one_win = <<<END
-Confine the user interface to one native window.
-i.e. Menus, Preview, popups are inside the main window area.
-END
-multi_win = <<<END
-Create one native window for each interface window.
-i.e. Menus, Preview, popups have their own window.
-END
+one_win = Confine the user interface to one native window.\ni.e. Menus, Preview, popups are inside the main window area.
+multi_win = Create one native window for each interface window.\ni.e. Menus, Preview, popups have their own window.
 theme_mode = Theme Mode:
 screen_scaling = Screen Scaling:
 ui_scaling = UI Elements Scaling:
@@ -1514,17 +1276,11 @@ show_menu_bar = Show Aseprite menu bar
 show_aseprite_file_dialog = Show Aseprite file dialog
 show_home = Show Home tab when Aseprite is started
 expand_menu_bar_items_on_mouseover = Expand menu bar items on mouseover
-expand_menu_bar_items_on_mouseover_tooltip = <<<END
-Check this option to get
-this old menus behavior.
-END
+expand_menu_bar_items_on_mouseover_tooltip = Check this option to get\nthis old menus behavior.
 color_bar_entries_separator = Draw a separation between each palette entry
 recover_files = Recover Files
 auto_save_recovery_data = Automatically save recovery data every
-auto_save_recovery_data_tooltip = <<<END
-With this option you can recover your documents
-if the program finalizes unexpectedly.
-END
+auto_save_recovery_data_tooltip = With this option you can recover your documents\nif the program finalizes unexpectedly.
 10_seconds = 10 Seconds
 30_seconds = 30 Seconds
 1_minute = 1 Minute
@@ -1537,11 +1293,7 @@ END
 4_hours = 4 Hours
 8_hours = 8 Hours
 keep_edited_sprite_data = Keep edited sprite data for
-keep_edited_sprite_data_tooltip = <<<END
-With this option you can re-open edited documents
-after closing the program for the number of specified
-days.
-END
+keep_edited_sprite_data_tooltip = With this option you can re-open edited documents\nafter closing the program for the number of specified\ndays.
 1_day = 1 Day
 2_days = 2 Days
 3_days = 3 Days
@@ -1549,16 +1301,9 @@ END
 2_weeks = 2 Weeks
 1_month = 1 Month
 show_full_path = Show full file name path
-show_full_path_tooltip = <<<END
-Uncheck this option if you would prefer to hide
-full path on UI (e.g. useful for live streaming)
-END
+show_full_path_tooltip = Uncheck this option if you would prefer to hide\nfull path on UI (e.g. useful for live streaming)
 keep_closed_sprite_on_memory = Keep closed sprite on memory for
-keep_closed_sprite_on_memory_tooltip = <<<END
-When you close a sprite, it will be kept on memory just in case if you
-have closed the sprite by mistake, so you can "undo" the close action
-using "File > Reopen Closed File" menu option.
-END
+keep_closed_sprite_on_memory_tooltip = When you close a sprite, it will be kept on memory just in case if you\nhave closed the sprite by mistake, so you can "undo" the close action\nusing "File > Open Recent > Reopen Closed File" menu option.
 default_extension_for = Default extension for:
 save_default_extension = File > Save:
 export_image_default_extension = File > Export (one image):
@@ -1582,12 +1327,7 @@ show_scrollbars_tooltip = Show scroll-bars in all sprite editors.
 auto_scroll = Auto-scroll on editor edges
 auto_fit = Auto-fit on screen when a sprite is opened
 straight_line_preview = Preview straight line immediately on Pencil tool
-straight_line_preview_tooltip = <<<END
-On Pencil tool you can draw straight lines
-using Shift+click, with this option checked
-you will see the preview immediately when
-the Shift key is pressed.
-END
+straight_line_preview_tooltip = On Pencil tool you can draw straight lines\nusing Shift + Click, with this option checked\nyou will see the preview immediately when\nthe Shift key is pressed.
 discard_brush = Discard custom brush when eyedropper is used
 right_click = Right-click:
 right_click_paint_bgcolor = Paint with background color
@@ -1599,83 +1339,35 @@ right_click_lasso = Lasso
 right_click_select_layer_and_move = Select Layer and Move
 editor_selection = Selection
 auto_opaque = Adjust opaque/transparent mode automatically
-auto_opaque_tooltip = <<<END
-Depending on the layer (background/transparent),
-the pasted selection will be adjusted
-automatically (opaque/transparent)
-END
+auto_opaque_tooltip = Depending on the layer (background/transparent),\nthe pasted selection will be adjusted\nautomatically (opaque/transparent)
 keep_selection_after_clear = Keep selection after "Edit > Delete" command
-keep_selection_after_clear_tooltip = <<<END
-Check this if you want to keep the selection
-after deleting it.
-END
+keep_selection_after_clear_tooltip = Check this if you want to keep the selection\nafter deleting it.
 auto_show_selection_edges = Show selection edges automatically when the selection is modified
-auto_show_selection_edges_tooltip = <<<END
-When checked, the View > Show > Selection Edges option will be enabled
-each time we modify the selection. Uncheck this in case that you want
-to keep selection edges hidden when View > Show > Selection Edges
-option is disabled, e.g. to avoid visual noise or performance issues.
-END
+auto_show_selection_edges_tooltip = When checked, the "View > Show > Selection Edges" option will be enabled\neach time we modify the selection. Uncheck this in case that you want\nto keep selection edges hidden when "View > Show > Selection Edges"\noption is disabled, e.g. to avoid visual noise or performance issues.
 move_edges = Allow moving selection edges
-move_edges_tooltip = <<<END
-Check this if you want to be able to drag
-only the selection edges when the mouse is
-above them.
-END
+move_edges_tooltip = Check this if you want to be able to drag\nonly the selection edges when the mouse is\nabove them.
 modifiers_disable_handles = Disable transformation handles when key modifiers are pressed
-modifiers_disable_handles_tooltip = <<<END
-If you press Shift/Ctrl/Alt keys, the handles
-to transform the selection will be temporarily
-disabled.
-END
+modifiers_disable_handles_tooltip = If you press Shift/Ctrl/Alt keys, the handles\nto transform the selection will be temporarily\ndisabled.
 move_on_add_mode = Move selection on Add mode
-move_on_add_mode_tooltip = <<<END
-On "Add to selection" mode, we can move
-the selection when the mouse is inside it.
-END
+move_on_add_mode_tooltip = On "Add to selection" mode, we can move\nthe selection when the mouse is inside it.
 select_tile_with_double_click = Select a grid tile with double-click
 force_rotsprite = Force RotSprite even for right/straight angles
 multicel_when_layers_or_frames = Transform cels in selected layers or frames on timeline
-multicel_when_layers_or_frames_tooltip = <<<END
-When you transform the selection, all selected cels in the timeline
-will be transformed. With this option if you select multiple layers or
-frames, the transformation will be applied to all cels of the selected
-layers/frames. Without this option, multiple cels will be transformed
-only if you select multiple cels explicitly in the timeline.
-END
+multicel_when_layers_or_frames_tooltip = When you transform the selection, all selected cels in the timeline\nwill be transformed. With this option if you select multiple layers or\nframes, the transformation will be applied to all cels of the selected\nlayers/frames. Without this option, multiple cels will be transformed\nonly if you select multiple cels explicitly in the timeline.
+snap_to_grid_selection = Snap To Grid when the option is enabled
 autotimeline = Show timeline automatically
-autotimeline_tooltip = <<<END
-Show the timeline automatically
-when a new frame or layer is added.
-END
+autotimeline_tooltip = Show the timeline automatically\nwhen a new frame or layer is added.
 rewind_on_stop = Rewind on Stop
-rewind_on_stop_tooltip = <<<END
-The 'Stop' button should rewind the animation
-where it was started.
-END
+rewind_on_stop_tooltip = The 'Stop' button should rewind the animation\nwhere it was started.
 timeline_selection = Timeline Range Selection
 keep_timeline_selection = Keep selection
-keep_timeline_selection_tooltip = <<<END
-Keep the selected range of layers/frames/cels
-when we edit the canvas / the timeline loses
-the focus.
-END
+keep_timeline_selection_tooltip = Keep the selected range of layers/frames/cels\nwhen we edit the canvas / the timeline loses\nthe focus.
 select_on_click = Select on Click
-select_on_click_tooltip = <<<END
-Enable the selected range of layers/frames/cels
-when we press the mouse button.
-END
-select_on_click_with_key = Select on Click + Shift
-select_on_click_with_key_tooltip = <<<END
-Enable the selected range of layers/frames/cels
-when we press the mouse button with the Shift key.
-END
+select_on_click_tooltip = Enable the selected range of layers/frames/cels\nwhen we press the mouse button.
+select_on_click_with_key = Select on Shift + Click
+select_on_click_with_key_tooltip = Enable the selected range of layers/frames/cels\nwhen we press the mouse button with the Shift key.
 select_on_drag = Select on Drag
-select_on_drag_tooltip = <<<END
-Enable the selected range of layers/frames/cels
-when we press the mouse button and after we move
-the mouse to another position.
-END
+select_on_drag_tooltip = Enable the selected range of layers/frames/cels\nwhen we press the mouse button and after we move\nthe mouse to another position.
 drag_and_drop_from_edges = Drag && drop from edges
 default_first_frame = Default First Frame:
 ui_mouse_cursor = UI Mouse Cursor
@@ -1723,18 +1415,10 @@ default_slice_color = Default Color:
 undo = Undo
 undo_show_tooltip = Show Undo Tooltip
 undo_size_limit = Undo Limit:
-undo_size_limit_tooltip = <<<END
-Limit of memory to be used
-for undo information per sprite.
-Specified in megabytes.
-END
+undo_size_limit_tooltip = Limit of memory to be used\nfor undo information per sprite.\nSpecified in megabytes.
 undo_mb = MB
 undo_goto_modified = Go to modified frame/layer
-undo_goto_modified_tooltip = <<<END
-When it's enabled each time you undo/redo
-the current frame & layer will be modified
-to focus the undid/redid change.
-END
+undo_goto_modified_tooltip = When it's enabled each time you undo/redo\nthe current frame & layer will be modified\nto focus the undid/redid change.
 undo_allow_nonlinear_history = Allow non-linear history
 open_sequence_alert = Open a sequence of static files as an animation
 open_sequence_alert_ask = Ask
@@ -1742,7 +1426,7 @@ open_sequence_alert_no = No
 open_sequence_alert_yes = Yes
 file_format_doesnt_support_alert = Show warning when saving a file with unsupported features
 export_animation_in_sequence_alert = Show warning when saving an animation as a sequence of static images
-overwrite_files_on_export_alert = Show warning when overwriting files on File > Export
+overwrite_files_on_export_alert = Show warning when overwriting files on "File > Export"
 overwrite_files_on_export_sprite_sheet_alert = Show warning when overwriting files on Export Sprite Sheet
 delete_tilemap_delete_unused_tileset_alert = Show warning when deleting a tilemap will delete its unused tileset
 image_format_alerts = Show options when saving files:
@@ -1793,16 +1477,9 @@ shaders_for_color_selectors = Use shaders for color selectors
 hue_with_sat_value = Apply Saturation/Value to Hue slider on Tint/Shade/Tone selector
 cache_compressed_tilesets = Cache compressed tilesets for faster save (uses more memory)
 one_finger_as_mouse_movement = Interpret one finger as mouse movement
-one_finger_as_mouse_movement_tooltip = <<<END
-Only for Windows 8/10 Pointer API: Interprets one finger as mouse movement
-and two fingers as pan/scroll. Uncheck this to use the old behavior:
-One finger pans/scrolls.
-END
+one_finger_as_mouse_movement_tooltip = Only for Windows 8/10 Pointer API: Interprets one finger as mouse movement\nand two fingers as pan/scroll. Uncheck this to use the old behavior:\nOne finger pans/scrolls.
 load_wintab_driver = Load wintab32 library
-load_wintab_driver_tooltip = <<<END
-Loads wintab32.dll driver to use Wacom-like devices
-when Aseprite is started.
-END
+load_wintab_driver_tooltip = Loads wintab32.dll driver to use Wacom-like devices\nwhen Aseprite is started.
 wintab_more_info = (More Information)
 flash_selected_layer = Flash layer when it is selected
 non_active_layer_opacity = Opacity for non-active layers:
@@ -1981,11 +1658,7 @@ size = Size:
 frames = Frames:
 advanced = Advanced
 transparent_color = Transparent Color:
-transparent_color_tooltip = <<<END
-Palette entry used as
-transparent color in each
-layer (only for indexed images).
-END
+transparent_color_tooltip = Palette entry used as\ntransparent color in each\nlayer (only for indexed images).
 pixel_ratio = Pixel Aspect Ratio:
 square_pixels = Square Pixels (1:1)
 double_wide = Double-wide Pixels (2:1)
@@ -2009,16 +1682,10 @@ title = Sprite Size
 pixels = Pixels:
 width = Width:
 width_px_tooltip = New width for the sprite (in pixels)
-width_perc_tooltip = <<<END
-New width for the sprite
-Percentage of current width.
-END
+width_perc_tooltip = New width for the sprite\nPercentage of current width.
 height = Height:
 height_px_tooltip = New height for the sprite (in pixels)
-height_perc_tooltip = <<<END
-New height for the sprite
-Percentage of current height.
-END
+height_perc_tooltip = New height for the sprite\nPercentage of current height.
 lock_ratio = Lock Ratio
 percentage = Percentage:
 interpolation = Interpolation:
@@ -2073,19 +1740,13 @@ opacity_step = Opacity Step:
 loop_tags = Loop through tag frames
 current_layer = Current layer only
 behind_sprite = Behind sprite
-behind_sprite_toolip = <<<END
-Only for transparent layers.
-Background is not included in this onion skin mode.
-END
+behind_sprite_toolip = Only for transparent layers.\nBackground is not included in this onion skin mode.
 in_front = In front of sprite
 in_front_toolip = For all kind of layers (background and transparents)
 
 [tools]
 rectangular_marquee = Rectangular Marquee Tool
-selection_tooltip = <<<END
-* Left Button: replace/add to current selection.
-* Right Button: remove from current selection.
-END
+selection_tooltip = * Left Button: replace/add to current selection.\n* Right Button: remove from current selection.
 elliptical_marquee = Elliptical Marquee Tool
 lasso_tool = Lasso Tool
 polygonal_lasso = Polygonal Lasso Tool
@@ -2093,11 +1754,7 @@ magic_wand = Magic Wand Tool
 pencil = Pencil Tool
 spray = Spray Tool
 eraser = Eraser Tool
-eraser_tooltip = <<<END
-* Left Button: Erase with the background color in 'Background' layer
-  or transparent color in any other layer.
-* Right Button: Replace foreground with background color.
-END
+eraser_tooltip = * Left Button: Erase with the background color in 'Background' layer\n  or transparent color in any other layer.\n* Right Button: Replace foreground with background color.
 eyedropper = Eyedropper Tool
 zoom = Zoom Tool
 hand = Hand Tool

--- a/data/package.json
+++ b/data/package.json
@@ -2,7 +2,7 @@
   "name": "language-chinese-traditional",
   "displayName": "Language - Chinese (Traditional)",
   "description": "Translation to Traditional Chinese by SiderealArt",
-  "version": "1.3-rc8",
+  "version": "1.3.2",
   "author": {
     "name": "SiderealArt",
     "url": "https://siderealart.me"

--- a/data/zh-hant.ini
+++ b/data/zh-hant.ini
@@ -1,5 +1,13 @@
 # Aseprite - Chinese (Traditional)
 # Copyright (C) 2021  5idereal (https://github.com/5idereal)
+#
+# This work is licensed under the Creative Commons Attribution 4.0
+# International License. To view a copy of this license, visit
+# http://creativecommons.org/licenses/by/4.0/ or send a letter to
+# Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+
+[_]
+display_name = 中文（繁體）
 
 [advanced_mode]
 title = 警告 - 重要
@@ -40,85 +48,29 @@ non_transformable_reference_layer = '{}' 為參考圖層，無法移動
 sprite_locked_somewhere = Sprite 被其他編輯器鎖定
 not_enough_transform_memory = 記憶體不足，無法變更選取區域
 not_enough_rotsprite_memory = 記憶體不足，無法使用 RotSprite
-cannot_modify_readonly_sprite = <<<END
-無法編輯唯讀 Sprite。
-使用檔案 > 儲存選單以了解更多資訊。
-END
+cannot_modify_readonly_sprite = 無法編輯唯讀 Sprite。\n使用檔案 > 儲存選單以了解更多資訊。
 
 [alerts]
 applying_filter = 效果<<正在套用效果...||取消
-auto_remap = <<<END
-自動重新對應
-<<自動重新對應無法完美為超過 256 種顏色操作，
-<<您確定要繼續嗎？
-||&OK||取消
-END
+auto_remap = 自動重新對應\n<<自動重新對應無法完美為超過 256 種顏色操作，\n<<您確定要繼續嗎？\n||&OK||取消
 cannot_delete_all_layers = 錯誤<<您無法刪除所有圖層。||&OK
-cannot_delete_used_tileset = <<<END
-錯誤
-<<無法刪除被下列 Tilemaps 所使用的方格組：
-<<'{0}'
-||&OK
-END
-deleting_tilemaps_will_delete_tilesets = <<<END
-警告
-<<刪除下列圖層會一併刪除其方格組：
-<<'{0}'
-<<您仍要繼續嗎？
-||&OK||取消
-END
-cannot_file_overwrite_on_export = <<<END
-覆寫警告
-<<您無法以相同名稱匯出 (覆蓋原檔案)。
-<<請使用 檔案 > 另存新檔。
-||&OK
-END
+cannot_delete_used_tileset = 錯誤\n<<無法刪除被下列 Tilemaps 所使用的方格組：\n<<'{0}'\n||&OK
+deleting_tilemaps_will_delete_tilesets = 警告\n<<刪除下列 Tilemaps 會一併刪除其方格組：\n<<'{0}'\n<<您仍要繼續嗎？\n||&OK||取消
+cannot_file_overwrite_on_export = 覆寫警告\n<<您無法以相同名稱匯出 (覆蓋原檔案)。\n<<請使用 檔案 > 另存新檔。\n||&OK
 cannot_open_file = 問題<<無法開啟檔案：<<{0}||&OK
 cannot_open_folder = 問題<<無法開啟資料夾：<<{0}||&OK
 cannot_save_in_read_only_file = 問題<<您選擇的檔案為唯讀。請試試其他檔案。||返回
 clipboard_access_locked = 錯誤<<無法存取剪貼簿。<<可能其他應用程式正在使用。||&OK
 clipboard_image_format_not_supported = 錯誤<<不支援目前剪貼簿中的圖片格式。||&OK
-delete_selected_backups = <<<END
-警告
-<<您確定要刪除已選的 {0} 個備份嗎？
-||是||否
-END
-delete_shortcut = <<<END
-警告
-<<您確定要刪除 '{0}' 鍵盤快捷鍵嗎？
-||是||否
-END
-empty_rect_importing_sprite_sheet = <<<END
-匯入 Sprite 表
-<<您指定的矩形無法建立任何方格。
-<<請在 Sprite 的區域中指定。
-||&OK
-END
+delete_selected_backups = 警告\n<<您確定要刪除已選的 {0} 個備份嗎？\n||是||否
+delete_shortcut = 警告\n<<您確定要刪除 '{0}' 鍵盤快捷鍵嗎？\n||是||否
+empty_rect_importing_sprite_sheet = 匯入 Sprite 表\n<<您指定的矩形無法建立任何方格。\n<<請在 Sprite 的區域中指定。\n||&OK
 error_loading_file = 錯誤<<無法載入檔案：{0}||&OK
 error_saving_file = 錯誤<<無法儲存檔案：{0}||&OK
-file_format_doesnt_support_palette = Error<<Cannot save a color palette in {0} format||&OK
-export_animation_in_sequence = <<<END
-提醒
-<<您確定要匯入 {0} 檔案中的動畫嗎？
-<<{1}, {2}...
-||同意||取消
-END
-file_format_doesnt_support_error = <<<END
-錯誤
-<<檔案格式 ".{0}" 不支援：
-{1}
-<<您必須選擇其他檔案格式。
-<<使用 ".ase" 來保留所有 Sprite 資訊。
-||&OK
-END
-file_format_doesnt_support_warning = <<<END
-警告
-<<檔案格式 ".{0}" 不支援：
-{1}
-<<您可以使用 ".ase" 來保留這些資訊。
-<<您確定要繼續使用 ".{0}" 嗎？
-||是||否
-END
+file_format_doesnt_support_palette = 錯誤<<無法將調色盤保存為 ｛0｝ 格式||&OK
+export_animation_in_sequence = 提醒\n<<您確定要匯入 {0} 檔案中的動畫嗎？\n<<{1}, {2}...\n||同意||取消
+file_format_doesnt_support_error = 錯誤\n<<檔案格式 ".{0}" 不支援：\n{1}\n<<您必須選擇其他檔案格式。\n<<使用 ".ase" 來保留所有 Sprite 資訊。\n||&OK
+file_format_doesnt_support_warning = 警告\n<<檔案格式 ".{0}" 不支援：\n{1}\n<<您可以使用 ".ase" 來保留這些資訊。\n<<您確定要繼續使用 ".{0}" 嗎？\n||是||否
 file_format_alpha_channel = Alpha 通道
 file_format_tags = 標籤
 file_format_frames = 影格
@@ -129,106 +81,32 @@ file_format_palette_changes = 調色盤將於影格間變更
 file_format_rgb_mode = RGB 模式
 file_format_20ms_min_duration = 影格長度小於 20 毫秒
 file_format_10ms_duration_precision = 影格長度非 10 毫秒的倍數
-invalid_chars_in_filename = <<<END
-錯誤
-<<檔名不得包含以下字元：
-<< {0}
-||&OK
-END
-invalid_fg_or_bg_colors = <<<END
-Aseprite
-<<目前選取的前景色和/或背景色已超出範圍。
-<<請選擇調色盤中的有效顏色。
-||&OK
-END
+invalid_chars_in_filename = 錯誤\n<<檔名不得包含以下字元：\n<< {0}\n||&OK
+invalid_fg_or_bg_colors = Aseprite\n<<目前選取的前景色和/或背景色已超出範圍。\n<<請選擇調色盤中的有效顏色。\n||&OK
 job_working = {0}<<運作中...||取消
 nothing_to_report = 崩潰報告<<無需回報||&OK
-install_extension = <<<END
-警告
-<<您確定要安裝以下的擴充功能嗎？
-<<'{0}'
-||安裝||取消
-END
-uninstall_extension_warning = <<<END
-警告
-<<您確定要移除 '{0}' 擴充功能嗎？
-||是||否
-END
-unknown_output_file_format_error = <<<END
-Aseprite
-<<在輸出檔名中包含了未知的檔案格式 '{0}'。
-||&OK
-END
-update_screen_ui_scaling_with_theme_values = <<<END
-調整畫面/介面縮放
-<<新的主題 '{0}' 想要調整一些數值：
-<<  畫面縮放： {1}% -> {2}%
-<<  介面縮放： {3}% -> {4}%
-<<要允許這些變更嗎？
-||&允許||&拒絕
-END
-update_extension = <<<END
-更新擴充功能
-<<擴充功能 '{0}' 已安裝。
-<<您確定要從 v{2} {1} 到 v{3} 嗎？
-||是||否
-END
+install_extension = 警告\n<<您確定要安裝以下的擴充功能嗎？\n<<'{0}'\n||安裝||取消
+uninstall_extension_warning = 警告\n<<您確定要移除 '{0}' 擴充功能嗎？\n||是||否
+unknown_output_file_format_error = Aseprite\n<<在輸出檔名中包含了未知的檔案格式 '{0}'。\n||&OK
+update_screen_ui_scaling_with_theme_values = 調整畫面/介面縮放\n<<新的主題 '{0}' 想要調整一些數值：\n<<  畫面縮放： {1}% -> {2}%\n<<  介面縮放： {3}% -> {4}%\n<<要允許這些變更嗎？\n||&允許||&拒絕
+update_extension = 更新擴充功能\n<<擴充功能 '{0}' 已安裝。\n<<您確定要從 v{2} {1} 到 v{3} 嗎？\n||是||否
 update_extension_downgrade = 降級
 update_extension_upgrade = 升級
 recent_file_doesnt_exist = Aseprite<<選擇的檔案不存在||&OK
 recent_folder_doesnt_exist = Aseprite<<選擇的資料夾不存在||&OK
-restart_by_preferences = <<<END
-Aseprite
-<<您必須要重新啟動程式才能看到對 {0} 的變更。
-||&OK
-END
+restart_by_preferences = Aseprite\n<<您必須要重新啟動程式才能看到對 {0} 的變更。\n||&OK
 restart_by_preferences_save_recovery_data_period = 每隔 X 分鐘自動儲存還原資料
 restart_by_preferences_keep_edited_sprite_data_lifespan = 編輯後的 Sprite 資料保留 X 天
 restart_by_preferences_keep_closed_sprite_on_memory_for = 將已關閉的 Sprite 在記憶體保留 X 分鐘
-restore_all_shortcuts = <<<END
-警告
-<<您確定要將所有鍵盤快捷鍵
-<<回復原廠設定嗎？
-||是||否
-END
-run_script = <<<END
-執行腳本
-<<您確定要執行以下的腳本嗎？
-<<
-<<  {0}
-<<
-<<警告：腳本可能會使 Aseprite 崩潰，
-<<在執行腳本前請先儲存檔案。
-||執行||取消
-END
-save_sprite_changes = <<<END
-警告
-<<要在{1}前先儲存
-<<對 "{0}" 的變更嗎？
-||儲存||不要儲存||取消
-END
+restore_all_shortcuts = 警告\n<<您確定要將所有鍵盤快捷鍵\n<<回復原廠設定嗎？\n||是||否
+run_script = 執行腳本\n<<您確定要執行以下的腳本嗎？\n<<\n<<  {0}\n<<\n<<警告：腳本可能會使 Aseprite 崩潰，\n<<在執行腳本前請先儲存檔案。\n||執行||取消
+save_sprite_changes = 警告\n<<要在{1}前先儲存\n<<對 "{0}" 的變更嗎？\n||儲存||不要儲存||取消
 save_sprite_changes_quitting = 退出
 save_sprite_changes_closing = 關閉
 overwrite_existent_file = 警告<<檔案已存在，要覆寫嗎？<<{0}||是||否||取消
-overwrite_files_on_export_sprite_sheet = <<<END
-匯出 Sprite 表警告
-<<您確定要覆寫以下的檔案嗎？
-{0}
-||是||否
-END
-overwrite_files_on_export = <<<END
-匯出警告
-<<您確定要覆寫以下的檔案嗎？
-<<{0}
-||是||否
-END
-enter_license_disabled = <<<END
-資訊
-<<您所使用的 Aseprite 不支援輸入授權金鑰。
-<<請從 https://aseprite.org/download 重新下載。
-<<啟用 Aseprite 將可使用自動更新。
-||&OK
-END
+overwrite_files_on_export_sprite_sheet = 匯出 Sprite 表警告\n<<您確定要覆寫以下的檔案嗎？\n{0}\n||是||否
+overwrite_files_on_export = 匯出警告\n<<您確定要覆寫以下的檔案嗎？\n<<{0}\n||是||否
+enter_license_disabled = 資訊\n<<您所使用的 Aseprite 不支援輸入授權金鑰。\n<<請從 https://aseprite.org/download 重新下載。\n<<啟用 Aseprite 將可使用自動更新。\n||&OK
 
 [brightness_contrast]
 title = 亮度/對比
@@ -276,18 +154,9 @@ sort_and_gradients = 排序和漸層
 presets = 預設
 options = 選項
 switch_tileset = 顯示方格組 / 點擊右鍵將僅顯示方格組
-tileset_mode_manual = <<<END
-手動：編輯現有方格，
-不自動建立新方格
-END
-tileset_mode_auto = <<<END
-自動：編輯並重複使用現有方格，
-在必要/可行時建立/刪除方格
-END
-tileset_mode_stack = <<<END
-堆疊：不編輯現有方格，
-自動產生並堆疊新方格
-END
+tileset_mode_manual = 手動：編輯現有方格，\n不自動建立新方格
+tileset_mode_auto = 自動：編輯並重複使用現有方格，\n在必要/可行時建立/刪除方格
+tileset_mode_stack = 堆疊：不編輯現有方格，\n自動產生並堆疊新方格
 set_as_default = 設為預設
 remap_palette = 重新對應調色盤
 remap_palette_tooltip = 使用新編號替換舊編號
@@ -347,10 +216,10 @@ ChangeBrush_DecrementAngle = 增加角度
 ChangeBrush_DecrementSize = 放大
 ChangeBrush_IncrementAngle = 減少角度
 ChangeBrush_IncrementSize = 縮小
-# TODO # ChangeBrush_FlipX = Flip Horizontally
-# TODO # ChangeBrush_FlipY = Flip Vertically
-# TODO # ChangeBrush_FlipD = Flip Diagonally
-# TODO # ChangeBrush_Rotate90CW = Rotate 90 CW
+ChangeBrush_FlipX = 水平翻轉
+ChangeBrush_FlipY = 垂直翻轉
+ChangeBrush_FlipD = 對角線翻轉
+ChangeBrush_Rotate90CW = 順時針旋轉 90 度
 ChangeColor = 更改顏色：{0}
 ChangeColor_IncrementFgIndex = 增加前景索引
 ChangeColor_DecrementFgIndex = 減少前景索引
@@ -362,7 +231,7 @@ ChangePixelFormat_Grayscale = 灰階
 ChangePixelFormat_Indexed = 索引
 ChangePixelFormat_Indexed_OrderedDithering = 有序索引抖動
 ChangePixelFormat_Indexed_OldDithering = 舊版索引抖動
-ChangePixelFormat_Indexed_ErrorDifussion = Floyd-Steinberg 錯誤擴散索引抖動
+ChangePixelFormat_Indexed_ErrorDiffusion = Floyd-Steinberg 錯誤擴散索引抖動
 ChangePixelFormat_MoreOptions = 更多選項
 Clear = 清除
 ClearCel = 清除賽璐珞片
@@ -498,19 +367,11 @@ OpenInFolder = 在資料夾開啟
 OpenScriptFolder = 開啟腳本資料夾
 OpenWithApp = 使用相關應用程式開啟
 Options = 選項
-PaletteEditor = 切換 {0}{1}{2}
-PaletteEditor_Edit = <<<END
- 編輯調色盤模式
-END
-PaletteEditor_And = <<<END
- 和
-END
-PaletteEditor_FgPopup = <<<END
- 前景色彈出
-END
-PaletteEditor_BgPopup = <<<END
- 背景色彈出
-END
+PaletteEditor = 切換{0}{1}{2}
+PaletteEditor_Edit = "編輯調色盤模式"
+PaletteEditor_And = 和
+PaletteEditor_FgPopup = "前景色彈出"
+PaletteEditor_BgPopup = "背景色彈出"
 PaletteSize = 調色盤大小
 Paste = 貼上
 PasteText = 插入文字
@@ -648,30 +509,15 @@ width = 寬度：
 height = 高度：
 borders = 邊框：
 left = 左方：
-left_tooltip = <<<END
-要在左側加入的行數。
-使用負數來移除行。
-END
+left_tooltip = 要在左側加入的行數。\n使用負數來移除行。
 top = 上方：
-top_tooltip = <<<END
-要在上方加入的列數。
-使用負數來移除列。
-END
+top_tooltip = 要在上方加入的列數。\n使用負數來移除列。
 right = 右方：
-right_tooltip = <<<END
-要在右方加入的行數。
-使用負數來移除行。
-END
+right_tooltip = 要在右方加入的行數。\n使用負數來移除行。
 bottom = 下方：
-bottom_tooltip = <<<END
-要在下方加入的列數。
-使用負數來移除列。
-END
+bottom_tooltip = 要在下方加入的列數。\n使用負數來移除列。
 trim = 裁剪掉畫布外的內容
-trim_tooltip = <<<END
-從圖像賽璐珞片中移除
-超出新畫布大小的內容。
-END
+trim_tooltip = 從圖像賽璐珞片中移除\n超出新畫布大小的內容。
 
 [cel_properties]
 title = 賽璐珞片屬性
@@ -770,24 +616,15 @@ pressure_tooltip = 透過繪圖筆的壓感偵測控制此參數
 velocity = 速度
 velocity_tooltip = 透過滑鼠移動速度控制此參數
 size = 大小
-size_tooltip = <<<END
-根據感測器數值
-調整筆刷大小
-END
+size_tooltip = 根據感測器數值\n調整筆刷大小
 angle = 角度
-angle_tooltip = <<<END
-根據感測器數值
-調整筆刷角度
-END
+angle_tooltip = 根據感測器數值\n調整筆刷角度
 min_size_tooltip = 當感測器達到最小值時的筆刷大小
 max_size_tooltip = 當感測器達到最大值時的筆刷大小
 min_angle_tooltip = 當感測器達到最小值時的筆刷角度
 max_angle_tooltip = 當感測器達到最大值時的筆刷角度
 gradient = 漸層
-gradient_tooltip = <<<END
-前景色及
-背景色間的漸層
-END
+gradient_tooltip = 前景色及\n背景色間的漸層
 max_point_value = 最小/最大值
 sensors_tweaks = 感測器臨界值
 
@@ -801,10 +638,7 @@ frames = 影格：
 anidir = 動畫方向：
 pixel_ratio = 套用像素長寬比
 for_twitter = 此動畫將上傳至 Twitter
-for_twitter_tooltip = <<<END
-將最後一個影格的時間縮短為四分之一，
-以便 Twitter 可以正確地播放動畫。
-END
+for_twitter_tooltip = 將最後一個影格的時間縮短為四分之一，\n以便 Twitter 可以正確地播放動畫。
 adjust_resize = 重新調整大小至 {0}%
 export = 匯出
 cancel = 取消
@@ -817,35 +651,20 @@ sprite = Sprite
 sprite_tooltip = 要匯出到 Sprite 表的 Sprite 樣本來源
 borders = 邊框
 borders_tooltip = 為每個 Sprite 加入或移除邊框
-expand_all_sections_tooltip = <<<END
-顯示所有區域
-
-按下 Ctrl + 點擊來同時顯示多個區域
-END
+expand_all_sections_tooltip = 顯示所有區域\n\n按下 Ctrl + 點擊來同時顯示多個區域
 layout = 樣式
 layout_tooltip = Sprite 在輸出結果中的擺放方式
 output = 輸出
 output_tooltip = 要儲存 Sprite 表的位置
 sheet_type = 排版類型：
-sheet_type_tooltip = <<<END
-指定 Sprite 的排列方式：
-* 水平：並排擺放。
-* 垂直：由上到下擺放。
-* 行：每一影格或標籤一行。
-* 列：每一影格或標籤一列。
-* 緊湊：以最佳方式擺放所有影格。
-END
+sheet_type_tooltip = 指定 Sprite 的排列方式：\n* 水平：並排擺放。\n* 垂直：由上到下擺放。\n* 行：每一影格或標籤一行。\n* 列：每一影格或標籤一列。\n* 緊湊：以最佳方式擺放所有影格。
 type_horz = 水平
 type_vert = 垂直
 type_rows = 行
 type_cols = 列
 type_pack = 緊湊
 constraints = 限制：
-constraints_tooltip = <<<END
-限制 Sprite 表的排版。
-例如：固定行/列數、或是
-固定長度/寬度 (像素)。
-END
+constraints_tooltip = 限制 Sprite 表的排版。\n例如：固定行/列數、或是\n固定長度/寬度 (像素)。
 constraint_fixed_none = 無
 constraint_fixed_cols = 固定列數
 constraint_fixed_rows = 固定欄數
@@ -855,10 +674,7 @@ constraint_fixed_size = 固定大小
 border = 邊框間隔：
 border_tooltip = 每一影格間和與 Sprite 表邊界的間隔
 shape = 間距：
-shape_tooltip = <<<END
-每一影格間的間距
-(也稱作形狀間隔)
-END
+shape_tooltip = 每一影格間的間距\n(也稱作形狀間隔)
 inner = 內部間隔：
 inner_tooltip = 影格邊界內的間隔
 trim_sprite = 修剪 Sprite
@@ -889,15 +705,9 @@ meta_layers = 圖層
 meta_tags = 標籤
 meta_slices = 切片
 data_filename_format = 檔名：
-data_filename_format_tooltip = <<<END
-在 JSON 資料中的每一影格將包含檔名 (能夠辨認的字串)，您可以
-使用 {layer}、{frame}、{tag}、{tagframe} 等參數來標記。
-END
+data_filename_format_tooltip = 在 JSON 資料中的每一影格將包含檔名 (能夠辨認的字串)，您可以\n使用 {layer}、{frame}、{tag}、{tagframe} 等參數來標記。
 data_tagname_format = 項目標籤名稱：
-data_tagname_format_tooltip = <<<END
-每個標籤在 JSON 資料中都會有一個名稱欄位，
-您可以使用 {filename}、{title}、{path}、{tag} 等欄位來自訂此名稱。
-END
+data_tagname_format_tooltip = 每個標籤在 JSON 資料中都會有一個名稱欄位，\n您可以使用 {filename}、{title}、{path}、{tag} 等欄位來自訂此名稱。
 preview = 預覽
 open_sprite_sheet = 開啟 Sprite 表
 export = 匯出
@@ -954,14 +764,11 @@ no = 否
 cancel = 取消
 user_data = 使用者資料
 dont_show = 不再顯示此提醒
-dont_show_tooltip = <<<END
-如果您希望使用預設選項，而不需
-每次詢問的話，請勾選。
-END
+dont_show_tooltip = 如果您希望使用預設選項，而不需\n每次詢問的話，請勾選。
 reset = 重設
 advanced_options = 進階選項
 unknown = 未知
-# TODO # same_in_all_tools = Same in all Tools
+same_in_all_tools = 所有工具相同
 
 [gif_options]
 title = GIF 選項
@@ -988,16 +795,9 @@ title = 主畫面
 new_file = 建立新檔...
 open_file = 開啟舊檔...
 recover_files = 復原檔案...
-recover_files_tooltip = <<<END
-復原已崩潰的工作階段
-中的檔案，或是在上次的
-工作階段未儲存的 Sprite。
-END
+recover_files_tooltip = 復原已崩潰的工作階段\n中的檔案，或是在上次的\n工作階段未儲存的 Sprite。
 share_crashdb = 與 Aseprite 開發者分享崩潰資料
-share_crashdb_tooltip = <<<END
-勾選以自動與 Aseprite 開發者分享崩潰資料。
-這能夠幫助我們找到新錯誤並改善 Aseprite 的穩定性。
-END
+share_crashdb_tooltip = 勾選以自動與 Aseprite 開發者分享崩潰資料。\n這能夠幫助我們找到新錯誤並改善 Aseprite 的穩定性。
 recent_files = 最近使用的檔案：
 recent_folders = 最近使用的資料夾：
 news = 新聞：
@@ -1027,15 +827,7 @@ cancel = 取消
 
 [incompat_file]
 title = 檔案不相容
-message = <<<END
-此檔案是由新版的 Aseprite 建立，包含了我們無法完整讀取的資料。
-
-該檔案已被標記為唯讀，以避免在儲存/覆寫時遺失資料。
-
-若要解決此情形：
-- 將 Aseprite 更新到最新版本，並重新開啟此檔案 (建議)，或
-- 使用 "檔案 > 另存新檔" 選項來以其他名稱儲存檔案 (原始檔案的資料仍會遺失)
-END
+message = 此檔案是由新版的 Aseprite 建立，包含了我們無法完整讀取的資料。\n\n該檔案已被標記為唯讀，以避免在儲存/覆寫時遺失資料。\n\n若要解決此情形：\n- 將 Aseprite 更新到最新版本，並重新開啟此檔案 (建議)，或\n- 使用 "檔案 > 另存新檔" 選項來以其他名稱儲存檔案 (原始檔案的資料仍會遺失)
 incompatibilities = 不相容：
 update_link = 更新 Aseprite
 
@@ -1404,14 +1196,9 @@ grid_height = 網格高度：
 name = 名稱：
 default_name = 方格組
 base_index = 基本編號：
-base_tooltip = <<<END
-標示出方格組中帶內容的首個方格的編號。預設從 1 開始，可自訂為其他數字。
-END
-# TODO # allowed_flips = Allowed Flips:
-# TODO # allowed_flips_tooltip = <<<END
-# TODO # Aseprite can reuse tiles matching automatically with their flipped
-# TODO # versions (in X, Y, or Diagonal axes) in Auto/Stack modes.
-# TODO # END
+base_tooltip = 標示出方格組中帶內容的首個方格的編號。預設從 1 開始，可自訂為其他數字。
+allowed_flips = 允許翻轉：
+allowed_flips_tooltip = Aseprite 可以在自動/堆疊模式下重用與其翻轉版本（X、Y 或對角線軸）自動匹配的方格。
 
 [tileset_selector_window]
 title = Tileset
@@ -1425,18 +1212,9 @@ color_mode = 色彩模式：
 rgba = RGBA
 grayscale = 灰階
 indexed = 索引
-rgba_tooltip = <<<END
-每個像素都有紅、綠、藍、以及透明度值。
-(每像素 32 位元)
-END
-grayscale_tooltip = <<<END
-每個像素都有一個灰階值和透明度值。
-(每像素 16 位元)
-END
-indexed_tooltip = <<<END
-每個像素都參照了調色盤。
-(每像素 8 位元)
-END
+rgba_tooltip = 每個像素都有紅、綠、藍、以及透明度值。\n(每像素 32 位元)
+grayscale_tooltip = 每個像素都有一個灰階值和透明度值。\n(每像素 16 位元)
+indexed_tooltip = 每個像素都參照了調色盤。\n(每像素 8 位元)
 background = 背景：
 transparent = 透明
 white = 白色
@@ -1484,14 +1262,8 @@ section_extensions = 擴充功能
 section_experimental = 測試性功能
 general = 一般
 ui_windows = 使用者介面：
-one_win = <<<END
-將使用者介面限制在一個原生視窗內。
-選單、預覽、彈出視窗等都在主視窗區域內。
-END
-multi_win = <<<END
-為每個介面視窗建立一個原生視窗。
-選單、預覽、彈出視窗等將有自己的視窗。
-END
+one_win = 將使用者介面限制在一個原生視窗內。\n選單、預覽、彈出視窗等都在主視窗區域內。
+multi_win = 為每個介面視窗建立一個原生視窗。\n選單、預覽、彈出視窗等將有自己的視窗。
 theme_mode = 主題模式：
 screen_scaling = 畫面縮放：
 ui_scaling = 介面縮放：
@@ -1500,20 +1272,14 @@ download_translations = 下載翻譯檔
 gpu_acceleration = GPU 加速
 gpu_acceleration_tooltip = 勾選此選項以啟用硬體加速
 show_menu_bar = 顯示 Aseprite 選單列
-# TODO # show_aseprite_file_dialog = Show Aseprite file dialog
+show_aseprite_file_dialog = 顯示 Aseprite 檔案對話框
 show_home = 啟動後顯示主畫面分頁
 expand_menu_bar_items_on_mouseover = 游標懸停後展開選單
-expand_menu_bar_items_on_mouseover_tooltip = <<<END
-勾選此選項以使
-用舊版的操作方式。
-END
+expand_menu_bar_items_on_mouseover_tooltip = 勾選此選項以使\n用舊版的操作方式。
 color_bar_entries_separator = 在每個調色盤項目之間劃分隔線
 recover_files = 復原檔案
 auto_save_recovery_data = 自動儲存復原檔案間隔
-auto_save_recovery_data_tooltip = <<<END
-此選項能讓您在 Aseprite
-意外關閉時復原您的檔案。
-END
+auto_save_recovery_data_tooltip = 此選項能讓您在 Aseprite\n意外關閉時復原您的檔案。
 10_seconds = 10 秒
 30_seconds = 30 秒
 1_minute = 1 分鐘
@@ -1526,11 +1292,7 @@ END
 4_hours = 4 小時
 8_hours = 8 小時
 keep_edited_sprite_data = 編輯後的 Sprite 資料保留
-keep_edited_sprite_data_tooltip = <<<END
-此選項能讓您在指定的天數後，
-即使已關閉程式，
-也能重新開啟編輯過的 Sprite。
-END
+keep_edited_sprite_data_tooltip = 此選項能讓您在指定的天數後，\n即使已關閉程式，\n也能重新開啟編輯過的 Sprite。
 1_day = 1 天
 2_days = 2 天
 3_days = 3 天
@@ -1538,16 +1300,9 @@ END
 2_weeks = 2 週
 1_month = 1 個月
 show_full_path = 顯示檔案完整路徑
-show_full_path_tooltip = <<<END
-如果您希望在介面中隱藏檔案的完整路徑的話，
-請取消勾選此選項。(直播時非常有用)
-END
+show_full_path_tooltip = 如果您希望在介面中隱藏檔案的完整路徑的話，\n請取消勾選此選項。(直播時非常有用)
 keep_closed_sprite_on_memory = 將已關閉的 Sprite 在記憶體保留
-keep_closed_sprite_on_memory_tooltip = <<<END
-在您關閉 Sprite 後，Aseprite 仍將該 Sprite
-保留在記憶體中，以防您意外關閉。在 "檔案 > 重新開啟已關閉的檔案"
-中即可找到您關閉的檔案。
-END
+keep_closed_sprite_on_memory_tooltip = 在您關閉 Sprite 後，Aseprite 仍將該 Sprite\n保留在記憶體中，以防您意外關閉。在 "檔案 > 重新開啟已關閉的檔案"\n中即可找到您關閉的檔案。
 default_extension_for = 預設格式：
 save_default_extension = 檔案 > 儲存：
 export_image_default_extension = 檔案 > 匯出 (單一圖片)：
@@ -1571,12 +1326,7 @@ show_scrollbars_tooltip = 在所有 Sprite 編輯器中顯示捲軸。
 auto_scroll = 碰到編輯器邊緣時自動捲動
 auto_fit = 開啟 Sprite 後自動調整大小以符合畫面
 straight_line_preview = 使用鉛筆工具時顯示即時直線預覽
-straight_line_preview_tooltip = <<<END
-使用鉛筆工具時，您可以同時按下 Shift 鍵
-並點擊以畫出直線。
-啟用此選項後，
-按下 Shift 鍵將立刻顯示預覽。
-END
+straight_line_preview_tooltip = 使用鉛筆工具時，您可以同時按下 Shift 鍵\n並點擊以畫出直線。\n啟用此選項後，\n按下 Shift 鍵將立刻顯示預覽。
 discard_brush = 使用滴管時清除自訂筆刷
 right_click = 右鍵：
 right_click_paint_bgcolor = 用背景色繪製
@@ -1588,77 +1338,36 @@ right_click_lasso = 套索
 right_click_select_layer_and_move = 選取圖層並移動
 editor_selection = 選擇區域
 auto_opaque = 自動切換透明/不透明模式
-auto_opaque_tooltip = <<<END
-根據圖層 (背景/透明)，
-自動調整貼上的
-選取區域 (不透明/透明)。
-END
+auto_opaque_tooltip = 根據圖層 (背景/透明)，\n自動調整貼上的\n選取區域 (不透明/透明)。
 keep_selection_after_clear = 在執行 "編輯 > 刪除" 後仍保留選取區域
-keep_selection_after_clear_tooltip = <<<END
-若您在刪除後仍想保留
-選取區域，請勾選此選項。
-END
+keep_selection_after_clear_tooltip = 若您在刪除後仍想保留\n選取區域，請勾選此選項。
 auto_show_selection_edges = 在修改選取區域後自動顯示選取邊緣
-auto_show_selection_edges_tooltip = <<<END
-如果您想要保留原本的選取區域
-邊緣，請取消勾選此選項。
-END
+auto_show_selection_edges_tooltip = 如果您想要保留原本的選取區域\n邊緣，請取消勾選此選項。
 move_edges = 允許移動選取區域邊界
-move_edges_tooltip = <<<END
-如果您想要在游標停在
-選取區域邊界時，能夠
-拖動選取區域，請勾選此選項。
-END
+move_edges_tooltip = 如果您想要在游標停在\n選取區域邊界時，能夠\n拖動選取區域，請勾選此選項。
 modifiers_disable_handles = 按下特殊鍵時停用變形控制點
-modifiers_disable_handles_tooltip = <<<END
-當您按下 Shift/Ctrl/Alt 鍵時，
-變形控制
-點將暫時停用。
-END
+modifiers_disable_handles_tooltip = 當您按下 Shift/Ctrl/Alt 鍵時，\n變形控制\n點將暫時停用。
 move_on_add_mode = 在加入模式時移動選取區域
-move_on_add_mode_tooltip = <<<END
-在 "新增至選取區域" 模式中，將游標移動到
-選取區域中即可移動選取區域。
-END
+move_on_add_mode_tooltip = 在 "新增至選取區域" 模式中，將游標移動到\n選取區域中即可移動選取區域。
 select_tile_with_double_click = 點擊兩下來選擇方格
 force_rotsprite = 即使是直角/平角也使用 RotSprite
 multicel_when_layers_or_frames = 轉換時間軸上所選圖層或影格中的賽璐珞片
-multicel_when_layers_or_frames_tooltip = <<<END
-轉換所選區域時，時間軸中所有選取的賽璐珞片都將被轉換。啟用此選項後，如果您選擇多個圖層或是影格，則所選圖層或影格的賽璐珞片都將被轉換。若未啟用此選項，則只有在時間軸中明確選取多個賽璐珞片時，才會轉換多個賽璐珞片。
-END
+multicel_when_layers_or_frames_tooltip = 轉換所選區域時，時間軸中所有選取的賽璐珞片都將被轉換。啟用此選項後，如果您選擇多個圖層或是影格，則所選圖層或影格的賽璐珞片都將被轉換。若未啟用此選項，則只有在時間軸中明確選取多個賽璐珞片時，才會轉換多個賽璐珞片。
+snap_to_grid_selection = 啟用此選項時對齊到網格
 autotimeline = 自動顯示時間軸
-autotimeline_tooltip = <<<END
-新增新影格或是圖層
-後自動顯示時間軸。
-END
+autotimeline_tooltip = 新增新影格或是圖層\n後自動顯示時間軸。
 rewind_on_stop = 停止後回到開頭
-rewind_on_stop_tooltip = <<<END
-若啟用此選項，按下停
-止按鈕後將回到開頭。
-END
-# TODO # timeline_selection = Timeline Range Selection
+rewind_on_stop_tooltip = 若啟用此選項，按下停\n止按鈕後將回到開頭。
+timeline_selection = 時間軸範圍選擇
 keep_timeline_selection = 保留選取區域
-keep_timeline_selection_tooltip = <<<END
-編輯畫布時仍保留圖層/
-影格/賽璐珞片的選取區域。
-END
-# TODO # select_on_click = Select on Click
-# TODO # select_on_click_tooltip = <<<END
-# TODO # Enable the selected range of layers/frames/cels
-# TODO # when we press the mouse button.
-# TODO # END
-# TODO # select_on_click_with_key = Select on Click + Shift
-# TODO # select_on_click_with_key_tooltip = <<<END
-# TODO # Enable the selected range of layers/frames/cels
-# TODO # when we press the mouse button with the Shift key.
-# TODO # END
-# TODO # select_on_drag = Select on Drag
-# TODO # select_on_drag_tooltip = <<<END
-# TODO # Enable the selected range of layers/frames/cels
-# TODO # when we press the mouse button and after we move
-# TODO # the mouse to another position.
-# TODO # END
-# TODO # drag_and_drop_from_edges = Drag && drop from edges
+keep_timeline_selection_tooltip = 編輯畫布時仍保留圖層/\n影格/賽璐珞片的選取區域。
+select_on_click = 點擊選擇
+select_on_click_tooltip = 當按下滑鼠按鈕時，啟用選定範圍的圖層/影格/賽璐珞片。
+select_on_click_with_key = 點擊並按住 Shift 鍵選擇
+select_on_click_with_key_tooltip = 當按住 Shift 鍵並按下滑鼠按鈕時，啟用選定範圍的圖層/影格/賽璐珞片。
+select_on_drag = 拖曳選擇
+select_on_drag_tooltip = 當按下滑鼠按鈕並將滑鼠移動到另一個位置時，啟用選定範圍的圖層/影格/賽璐珞片。
+drag_and_drop_from_edges = 從邊緣拖放
 default_first_frame = 預設首影格：
 ui_mouse_cursor = 介面游標
 native_cursor = 使用原始游標
@@ -1676,7 +1385,7 @@ brush_preview_fullnedges = 完整預覽和邊界
 cursor_color_type = 準心及筆刷邊界顏色：
 cursor_neg_bw = 反白
 cursor_specific_color = 特定顏色
-# TODO # snap_cursor_to_grid = Snap To Grid when the option is enabled
+snap_cursor_to_grid = 啟用此選項時對齊到網格
 bg_checkered = 棋盤背景
 bg_size = 大小：
 bg_custom_size = 自訂
@@ -1705,18 +1414,10 @@ default_slice_color = 預設顏色：
 undo = 復原
 undo_show_tooltip = 顯示復原提示框
 undo_size_limit = 復原限制：
-undo_size_limit_tooltip = <<<END
-每個 Sprite 能使用
-的復原資訊大小。
-單位為 MB。
-END
+undo_size_limit_tooltip = 每個 Sprite 能使用\n的復原資訊大小。\n單位為 MB。
 undo_mb = MB
 undo_goto_modified = 前往修改的影格/圖層
-undo_goto_modified_tooltip = <<<END
-此選項啟用後，每次您復原
-或取消復原後，將跳至您
-修改後的影格或圖層。
-END
+undo_goto_modified_tooltip = 此選項啟用後，每次您復原\n或取消復原後，將跳至您\n修改後的影格或圖層。
 undo_allow_nonlinear_history = 允許非線性紀錄
 open_sequence_alert = 將一系列的靜態檔案作為動畫開啟
 open_sequence_alert_ask = 詢問我
@@ -1775,16 +1476,9 @@ shaders_for_color_selectors = 顏色選擇器使用著色器
 hue_with_sat_value = 對色彩/色度/色調選擇器套用飽和度/明度至色相滑條
 cache_compressed_tilesets = 將壓縮後的方格組存入快取以加快儲存速度 (使用更多記憶體)
 one_finger_as_mouse_movement = 將單指視為滑鼠移動
-one_finger_as_mouse_movement_tooltip = <<<END
-僅限 Windows 8/10 Pointer API：將單指視為滑鼠移動
-，雙指視為平移及滾動。取消勾選此選項
-以使用舊版操作：單指視為平移及滾動。
-END
+one_finger_as_mouse_movement_tooltip = 僅限 Windows 8/10 Pointer API：將單指視為滑鼠移動\n，雙指視為平移及滾動。取消勾選此選項\n以使用舊版操作：單指視為平移及滾動。
 load_wintab_driver = 載入 wintab32 函式庫
-load_wintab_driver_tooltip = <<<END
-Aseprite 啟動時必須載入 wintab32.dll 驅動程式
-才能使用 Wacom 及其他類似裝置。
-END
+load_wintab_driver_tooltip = Aseprite 啟動時必須載入 wintab32.dll 驅動程式\n才能使用 Wacom 及其他類似裝置。
 wintab_more_info = (更多資訊)
 flash_selected_layer = 當圖層被選取時閃爍
 non_active_layer_opacity = 非使用中圖層透明度：
@@ -1963,11 +1657,7 @@ size = 大小：
 frames = 影格：
 advanced = 進階
 transparent_color = 透明度顏色：
-transparent_color_tooltip = <<<END
-在每個圖層中，作為透明色的
-調色盤項目
-(僅限索引圖片)。
-END
+transparent_color_tooltip = 在每個圖層中，作為透明色的\n調色盤項目\n(僅限索引圖片)。
 pixel_ratio = 像素長寬比：
 square_pixels = 方形 (1：1)
 double_wide = 寬度加倍 (2：1)
@@ -1991,16 +1681,10 @@ title = Sprite 大小
 pixels = 像素：
 width = 寬度：
 width_px_tooltip = Sprite 的新寬度 (單位為像素)
-width_perc_tooltip = <<<END
-Sprite 的新寬度
-目前寬度的百分比。
-END
+width_perc_tooltip = Sprite 的新寬度\n目前寬度的百分比。
 height = 高度：
 height_px_tooltip = Sprite 的新高度 (單位為像素)
-height_perc_tooltip = <<<END
-Sprite 的新高度
-目前高度的百分比。
-END
+height_perc_tooltip = Sprite 的新高度\n目前高度的百分比。
 lock_ratio = 鎖定長寬比
 percentage = 百分比：
 interpolation = 插值：
@@ -2055,19 +1739,13 @@ opacity_step = 透明度 Step：
 loop_tags = 在有標籤的影格中循環
 current_layer = 僅目前影格
 behind_sprite = 影格後方
-behind_sprite_toolip = <<<END
-僅適用於透明圖層，
-此模式不包含背景。
-END
+behind_sprite_toolip = 僅適用於透明圖層，\n此模式不包含背景。
 in_front = 影格前方
 in_front_toolip = 適用於所有類型的圖層 (背景和透明圖層)。
 
 [tools]
 rectangular_marquee = 矩形選取工具
-selection_tooltip = <<<END
-* 左鍵：取代/增加至目前的選取區域。
-* 右鍵：從目前的選取區域中減去。
-END
+selection_tooltip = * 左鍵：取代/增加至目前的選取區域。\n* 右鍵：從目前的選取區域中減去。
 elliptical_marquee = 橢圓選取工具
 lasso_tool = 套索工具
 polygonal_lasso = 多邊形套索工具
@@ -2075,11 +1753,7 @@ magic_wand = 魔術棒工具
 pencil = 鉛筆工具
 spray = 噴漆工具
 eraser = 橡皮擦工具
-eraser_tooltip = <<<END
-* 左鍵： 在背景圖層中以背景色擦除，
-  在其他圖層中則以透明色擦除。
-* 右鍵： 將前景色以背景色替代。
-END
+eraser_tooltip = * 左鍵： 在背景圖層中以背景色擦除，\n  在其他圖層中則以透明色擦除。\n* 右鍵： 將前景色以背景色替代。
 eyedropper = 滴管工具
 zoom = 縮放工具
 hand = 手形工具
@@ -2100,8 +1774,8 @@ jumble = 打亂工具
 shortcut = 快捷鍵：{0}
 preview_hide = 隱藏預覽
 preview_show = 顯示預覽
-# TODO # timeline_hide = Hide Timeline
-# TODO # timeline_show = Show Timeline
+timeline_hide = 隱藏時間軸
+timeline_show = 顯示時間軸
 
 [undo_history]
 title = 復原紀錄

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-aseprite-ini==0.0.3
+aseprite-ini==0.0.4

--- a/update.py
+++ b/update.py
@@ -12,7 +12,7 @@ data_dir = os.path.join(project_root_dir, 'data')
 
 
 def main():
-    strings_en = Aseini.pull_strings('v1.3-rc8')
+    strings_en = Aseini.pull_strings('main')
     strings_en.save(os.path.join(strings_dir, 'en.ini'))
     logger.info("Update strings: 'en.ini'")
 


### PR DESCRIPTION
目前翻译已经迁移到 [Weblate](https://hosted.weblate.org/projects/aseprite/aseprite/)
计划在后续的某一个版本开始，翻译会成为内置，而语言扩展包的形式将会过时。

官方要求翻译必须由原始作者亲自导入，因此您必须亲自完成上传动作（这样将会保留您的 git 翻译提交贡献）

本次 PR 已经针对 Weblate 格式要求进行了调整，并且已经针对 1.3.2 版本补全了缺失文本

上传地址为：

https://hosted.weblate.org/projects/aseprite/aseprite/zh_Hant/#upload

请使用本次 PR 中的翻译文件，按照如下选项进行提交：

![image](https://github.com/5idereal/Aseprite-Traditional-Chinese-Translation/assets/6064962/e6497e18-6e3b-4f0c-9e9b-09b018da5044)

如果一切顺利，繁体中【已翻译】 应为 100%

有任何问题，请随时反馈！



